### PR TITLE
Rediseñar interfaz para cálculo de propiedades del agua

### DIFF
--- a/Prop-Agua streamlit.py
+++ b/Prop-Agua streamlit.py
@@ -1,28 +1,68 @@
 import streamlit as st
 import CoolProp.CoolProp as cp
-
-# Inicializar claves en session_state
-if 't' not in st.session_state:
-    st.session_state['t'] = None
-if 's' not in st.session_state:
-    st.session_state['s'] = None
+import matplotlib.pyplot as plt
+import numpy as np
+from CoolProp.CoolProp import PropsSI
 
 # Título de la aplicación
 st.subheader("Termodinámica - Máquinas Térmicas - Tecnología del Calor")
 st.title("💧 Calculador de propiedades del agua")
-# Separador
 st.markdown("---")
 
-# Definir funciones para cálculos específicos
+# Variables disponibles
+VARIABLES = ['p', 't', 'v', 'u', 'h', 's', 'x']
+FMT = {
+    'p': '{:.2f}',
+    't': '{:.2f}',
+    'v': '{:.4f}',
+    'u': '{:.2f}',
+    'h': '{:.2f}',
+    's': '{:.4f}',
+    'x': '{:.4f}',
+}
+
+# Inicialización del estado
+for var in VARIABLES:
+    st.session_state.setdefault(var, '')
+st.session_state.setdefault('first_input', None)
+st.session_state.setdefault('second_input', None)
+st.session_state.setdefault('t_num', None)
+st.session_state.setdefault('s_num', None)
+st.session_state.setdefault('calculado', False)
+st.session_state.setdefault('resultados', None)
+
+# Actualizar los valores calculados antes de instanciar los widgets
+if st.session_state.get('resultados'):
+    resultados = st.session_state.pop('resultados')
+    for var in VARIABLES:
+        valor = resultados.get(var)
+        st.session_state[var] = FMT[var].format(valor) if valor is not None else ''
+    st.session_state['t_num'] = resultados.get('t')
+    st.session_state['s_num'] = resultados.get('s')
+    st.session_state['calculado'] = True
+
+
+def manejar_cambio(key):
+    """Borra los otros inputs al ingresar el primer valor."""
+    valor = st.session_state.get(key, '')
+    if st.session_state.get('first_input') is None:
+        if valor != '':
+            st.session_state['first_input'] = key
+            st.session_state['second_input'] = None
+            for var in VARIABLES:
+                if var != key:
+                    st.session_state[var] = ''
+            st.session_state['calculado'] = False
+            st.session_state['t_num'] = None
+            st.session_state['s_num'] = None
+    elif st.session_state.get('first_input') != key and st.session_state.get('second_input') is None:
+        if valor != '':
+            st.session_state['second_input'] = key
+
+
 def calcular_propiedades(desde, **kwargs):
-    t = None
-    p = None
-    v = None
-    u = None
-    h = None
-    s = None
-    x = None
-    
+    """Calcula todas las propiedades del agua a partir de un par de variables."""
+    t = p = v = u = h = s = x = None
     try:
         if desde == 'TP':
             t_kelvin = kwargs['t'] + 273.15
@@ -129,42 +169,14 @@ def calcular_propiedades(desde, **kwargs):
             x = cp.PropsSI('Q', 'T', t_kelvin, 'D', rho, 'Water')
             p = p_pascal / 1e5
 
-        # Devolver todas las propiedades calculadas
-        st.session_state['t'] = t
-        st.session_state['s'] = s
-        st.session_state['calculado'] = True
         return t, p, v, u, h, s, x
-
-
     except Exception as e:
         st.error(f"Error en el cálculo: {e}")
-        st.session_state['t'] = None
-        st.session_state['s'] = None
         st.session_state['calculado'] = False
         return None, None, None, None, None, None, None
 
 
-
-# Formulario para seleccionar la opción
-def reset_calculado():
-    st.session_state['calculado'] = False
-
-st.sidebar.title("Seleccioná una opción:")
-option = st.sidebar.radio(
-    "",
-    ("t y p",
-     "p y h",
-     "h y s",
-     "p y x",
-     "t y x",
-     "p y s",
-     "t y s",
-     "p y v",
-     "t y v"),
-    on_change=reset_calculado,
-)
-
-# Texto adicional
+# Barra lateral informativa
 st.sidebar.write("Desarrollado por P Sobral para **Termodinámica**.")
 st.sidebar.write("Versión: 0.01.")
 st.sidebar.write("Contacto: psobral@fi.uba.ar.")
@@ -172,226 +184,81 @@ st.sidebar.write("Powered by CoolProp.")
 st.sidebar.markdown("[Readme.md](https://github.com/psobral2/Prop-Agua/blob/main/README.md)")
 
 
-if option == 't y p':
+st.write("### Ingrese dos propiedades en las casillas correspondientes")
 
-    # Formulario para Temperatura y Presión
-    st.write("### Temperatura y Presión")
+col1, col2, col3 = st.columns(3)
+with col1:
+    st.text_input("Presión [bar(a)]", key='p', on_change=manejar_cambio, args=('p',))
+    st.text_input("Volumen específico [m³/kg]", key='v', on_change=manejar_cambio, args=('v',))
+    st.text_input("Entalpía [kJ/kg]", key='h', on_change=manejar_cambio, args=('h',))
+with col2:
+    st.text_input("Temperatura [°C]", key='t', on_change=manejar_cambio, args=('t',))
+    st.text_input("Energía interna [kJ/kg]", key='u', on_change=manejar_cambio, args=('u',))
+    st.text_input("Entropía [kJ/(kg·K)]", key='s', on_change=manejar_cambio, args=('s',))
+with col3:
+    st.text_input("Título [0-1]", key='x', on_change=manejar_cambio, args=('x',))
 
-    with st.form(key='tp_form'):
-        t = st.number_input("Ingrese la temperatura [°C]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        p_t = st.number_input("Ingrese la presión [bar(a)]", value=1.0, step=0.01, format="%.2f", min_value=0.0)
 
-        tp_submit_button = st.form_submit_button(label='Calcular desde Temperatura y Presión')
-
-    if tp_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('TP', t=t, p=p_t)
-
-        if t is not None:
-            st.write(f"Resultados a {t:.2f} °C y {p:.2f} bar(a):")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-            st.write(f"Título: {x:.4f}")
+if st.button("Calcular"):
+    valores = {k: st.session_state[k] for k in VARIABLES if st.session_state[k] not in ('', None)}
+    if len(valores) != 2:
+        st.error("Por favor, ingrese exactamente dos valores.")
+    else:
+        pair_map = {
+            frozenset({'t', 'p'}): 'TP',
+            frozenset({'p', 'h'}): 'PH',
+            frozenset({'h', 's'}): 'HS',
+            frozenset({'p', 'x'}): 'PX',
+            frozenset({'t', 'x'}): 'TX',
+            frozenset({'p', 's'}): 'PS',
+            frozenset({'t', 's'}): 'TS',
+            frozenset({'p', 'v'}): 'PV',
+            frozenset({'t', 'v'}): 'TV',
+        }
+        clave = pair_map.get(frozenset(valores.keys()))
+        if clave is None:
+            st.error("Combinación de propiedades no soportada.")
         else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
+            try:
+                parsed = {k: float(v) for k, v in valores.items()}
+            except ValueError:
+                st.error("Los valores deben ser numéricos.")
+            else:
+                t, p, v, u, h, s, x = calcular_propiedades(clave, **parsed)
+                if t is not None:
+                    st.session_state['resultados'] = {
+                        'p': p,
+                        't': t,
+                        'v': v,
+                        'u': u,
+                        'h': h,
+                        's': s,
+                        'x': x,
+                    }
+                    st.session_state['first_input'] = None
+                    st.session_state['second_input'] = None
+                    try:
+                        st.rerun()
+                    except AttributeError:
+                        st.experimental_rerun()
 
-
-elif option == 'p y h':
-
-
-    # Formulario para Presión y Entalpía
-    st.write("### Presión y Entalpía")
-    with st.form(key='ph_form'):
-        h = st.number_input("Ingrese la entalpía [kJ/kg]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        p_h = st.number_input("Ingrese la presión [bar(a)]", value=1.0, step=0.01, format="%.2f", min_value=0.0)
-        ph_submit_button = st.form_submit_button(label='Calcular desde Presión y Entalpía')
-
-    if ph_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('PH', h=h, p=p_h)
-        if t is not None:
-            st.write(f"Resultados a {h:.2f} kJ/kg y {p:.2f} bar(a):")
-            st.write(f"Temperatura: {t:.2f} °C")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-
-elif option == 'h y s':
-
-    # Formulario para Entalpía y Entropía
-    st.write("### Entalpía y Entropía")
-    with st.form(key='hs_form'):
-        h = st.number_input("Ingrese la entalpía [kJ/kg]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        s = st.number_input("Ingrese la entropía [kJ/(kg·K)]", value=0.0, step=0.01, format="%.4f", min_value=0.0)
-        hs_submit_button = st.form_submit_button(label='Calcular desde Entalpía y Entropía')
-
-    if hs_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('HS', h=h, s=s)
-        if t is not None:
-            st.write(f"Resultados a {h:.2f} kJ/kg y {s:.4f} kJ/(kg·K):")
-            st.write(f"Temperatura: {t:.2f} °C")
-            st.write(f"Presión: {p:.2f} bar(a)")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-elif option == 'p y x':
-
-    # Formulario para Presión y Título
-    st.write("### Presión y Título")
-    with st.form(key='px_form'):
-        p = st.number_input("Ingrese la presión [bar(a)]", value=1.0, step=0.01, format="%.2f", min_value=0.0)
-        x = st.number_input("Ingrese el título (calidad del vapor) [0-1]", value=0.0, step=0.01, format="%.2f", min_value=0.0, max_value=1.0)
-        px_submit_button = st.form_submit_button(label='Calcular desde Presión y Título')
-
-    if px_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('PX', p=p, x=x)
-        if t is not None:
-            st.write(f"Resultados a {p:.2f} bar(a) y {x:.4f}:")
-            st.write(f"Temperatura: {t:.2f} °C")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-
-elif option == 't y x':
-
-    # Formulario para Temperatura y Título
-    st.write("### Temperatura y Título")
-    with st.form(key='tx_form'):
-        t = st.number_input("Ingrese la temperatura [°C]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        x = st.number_input("Ingrese el título (calidad del vapor) [0-1]", value=0.0, step=0.01, format="%.2f", min_value=0.0, max_value=1.0)
-        tx_submit_button = st.form_submit_button(label='Calcular desde Temperatura y Título')
-
-    if tx_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('TX', t=t, x=x)
-        if t is not None:
-            st.write(f"Resultados a {t:.2f} °C y {x:.4f}:")
-            st.write(f"Presión: {p:.2f} bar(a)")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-
-elif option == 'p y v':
-
-    # Formulario para Presión y Volumen específico
-    st.write("### Presión y Volumen específico")
-    with st.form(key='pv_form'):
-        p = st.number_input("Ingrese la presión [bar(a)]", value=1.0, step=0.01, format="%.2f", min_value=0.0)
-        v_input = st.number_input("Ingrese el volumen específico [m³/kg]", value=0.001, step=0.0001, format="%.4f", min_value=0.0)
-        pv_submit_button = st.form_submit_button(label='Calcular desde Presión y Volumen específico')
-
-    if pv_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('PV', p=p, v=v_input)
-        if t is not None:
-            st.write(f"Resultados a {p:.2f} bar(a) y {v:.4f} m³/kg:")
-            st.write(f"Temperatura: {t:.2f} °C")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-elif option == 't y v':
-
-    # Formulario para Temperatura y Volumen específico
-    st.write("### Temperatura y Volumen específico")
-    with st.form(key='tv_form'):
-        t = st.number_input("Ingrese la temperatura [°C]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        v_input = st.number_input("Ingrese el volumen específico [m³/kg]", value=0.001, step=0.0001, format="%.4f", min_value=0.0)
-        tv_submit_button = st.form_submit_button(label='Calcular desde Temperatura y Volumen específico')
-
-    if tv_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('TV', t=t, v=v_input)
-        if t is not None:
-            st.write(f"Resultados a {t:.2f} °C y {v:.4f} m³/kg:")
-            st.write(f"Presión: {p:.2f} bar(a)")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Entropía: {s:.4f} kJ/(kg·K)")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-elif option == 'p y s':
-
-    # Formulario para Presión y Entropía
-    st.write("### Presión y Entropía")
-    with st.form(key='ps_form'):
-        p = st.number_input("Ingrese la presión [bar(a)]", value=1.0, step=0.01, format="%.2f", min_value=0.0)
-        s = st.number_input("Ingrese la entropía [kJ/(kg·K)]", value=0.0, step=0.01, format="%.4f", min_value=0.0)
-        ps_submit_button = st.form_submit_button(label='Calcular desde Presión y Entropía')
-
-    if ps_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('PS', p=p, s=s)
-        if t is not None:
-            st.write(f"Resultados a {p:.2f} bar(a) y {s:.4f} kJ/(kg·K):")
-            st.write(f"Temperatura: {t:.2f} °C")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-elif option == 't y s':
-
-    # Formulario para Temperatura y Entropía
-    st.write("### Temperatura y Entropía")
-    with st.form(key='ts_form'):
-        t = st.number_input("Ingrese la temperatura [°C]", value=0.0, step=0.01, format="%.2f", min_value=0.0)
-        s = st.number_input("Ingrese la entropía [kJ/(kg·K)]", value=0.0, step=0.01, format="%.4f", min_value=0.0)
-        ts_submit_button = st.form_submit_button(label='Calcular desde Temperatura y Entropía')
-
-    if ts_submit_button:
-        t, p, v, u, h, s, x = calcular_propiedades('TS', t=t, s=s)
-        if t is not None:
-            st.write(f"Resultados a {t:.2f} °C y {s:.4f} kJ/(kg·K):")
-            st.write(f"Presión: {p:.2f} bar(a)")
-            st.write(f"Volumen específico: {v:.4f} m³/kg")
-            st.write(f"Energía interna: {u:.2f} kJ/kg")
-            st.write(f"Entalpía: {h:.2f} kJ/kg")
-            st.write(f"Título: {x:.4f}")
-        else:
-            st.write(f"Revisá que sean coherentes los valores ingresados, y volvé a intentarlo.")
-
-import matplotlib.pyplot as plt
-import numpy as np
-from CoolProp.CoolProp import PropsSI
 
 if st.session_state.get('calculado', False):
-    t_session = st.session_state.get('t')
-    s_session = st.session_state.get('s')
+    t_session = st.session_state.get('t_num')
+    s_session = st.session_state.get('s_num')
     if t_session is not None and s_session is not None:
-        # Crear curva de saturación para agua
-        Tsat = np.linspace(273.15, 647.095, 500)  # Desde 0°C a punto crítico
-        s_liq = [PropsSI("S", "T", T, "Q", 0, "Water") / 1000 for T in Tsat]  # kJ/kg.K
-        s_vap = [PropsSI("S", "T", T, "Q", 1, "Water") / 1000 for T in Tsat]  # kJ/kg.K
-        T_C = Tsat - 273.15  # Convertir a °C para mostrar
+        Tsat = np.linspace(273.15, 647.095, 500)
+        s_liq = [PropsSI("S", "T", T, "Q", 0, "Water") / 1000 for T in Tsat]
+        s_vap = [PropsSI("S", "T", T, "Q", 1, "Water") / 1000 for T in Tsat]
+        T_C = Tsat - 273.15
 
-        # Punto del usuario
-        s_user = s_session  # kJ/kg.K
-        T_user = t_session  # °C
+        s_user = s_session
+        T_user = t_session
 
-        # Graficar
         fig, ax = plt.subplots()
         ax.plot(s_liq, T_C, label="Líquido saturado", color="blue")
         ax.plot(s_vap, T_C, label="Vapor saturado", color="red")
-        ax.plot(s_user, T_user, "ko", label="Punto ingresado")  # Punto del usuario
+        ax.plot(s_user, T_user, "ko", label="Punto ingresado")
 
         ax.set_xlabel("Entropía específica [kJ/kg·K]")
         ax.set_ylabel("Temperatura [°C]")
@@ -399,10 +266,5 @@ if st.session_state.get('calculado', False):
         ax.grid(True)
         ax.legend()
 
-        # Mostrar en Streamlit
         st.pyplot(fig)
 
-# Separador
-#st.markdown("---")
-# Texto adicional
-#st.write("Desarrollado por P. Sobral para **Termodinámica**. Versión: 0.01. Contacto: psobral@fi.uba.ar. Powered by CoolProp. Ver [Readme.md](https://github.com/psobral2/Prop-Agua/blob/main/README.md) en Github.")


### PR DESCRIPTION
## Summary
- Preparar formato para cada propiedad y actualizar los widgets antes de instanciarlos usando `resultados`
- Guardar los resultados tras presionar **Calcular** y forzar un rerun seguro para evitar la excepción de Streamlit

## Testing
- `python -m py_compile 'Prop-Agua streamlit.py'`


------
https://chatgpt.com/codex/tasks/task_e_6897c972cd7883339d702740dc5bba0d